### PR TITLE
post-hackathon bug fixes and adjustments 

### DIFF
--- a/app/[username]/profile/delete-account.tsx
+++ b/app/[username]/profile/delete-account.tsx
@@ -14,8 +14,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import { signOut } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { toast } from "sonner";
 
 export function DeleteAccount({ userId }: { userId: string }) {
     const [isDeleting, setIsDeleting] = useState(false);
@@ -28,12 +28,13 @@ export function DeleteAccount({ userId }: { userId: string }) {
             });
 
             if (!response.ok) {
-                throw new Error('Failed to delete account');
+                toast.error('Failed to delete account');
             }
 
-            await signOut({ redirectTo: "/" });
+            await signOut({ redirectTo: '/' });
         } catch (error) {
             console.error('Error deleting account:', error);
+            toast.error('Failed to delete account');
             setIsDeleting(false);
         }
     };

--- a/app/[username]/profile/page.tsx
+++ b/app/[username]/profile/page.tsx
@@ -58,18 +58,15 @@ async function getUser(name: string, isCurrentUser = false) {
 
 
 type Props = {
-    params: Promise<{ id: string }>
+    params: Promise<{ username: string }>
     searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
 export async function generateMetadata(
-    { params, searchParams }: Props,
-    parent: ResolvingMetadata
+    { params }: Props,
 ): Promise<Metadata> {
-    const id = (await params).id
-
+    const id = (await params).username;
     const user = await getUser(id) ?? null;
-    const numberOfImages = user?.UserImage.length;
     const name = user?.name ?? ""
 
     return {
@@ -102,7 +99,7 @@ export async function generateMetadata(
         openGraph: {
             title: `${name}'s Profile - Seleneo`,
             description: `Explore ${name}'s designs and images, as shared on Seleneo.`,
-            url: `https://freedesign.fyi/${encodeURIComponent(name)}/profile`,
+            url: `https://freedesign.fyi/${name}/profile`,
             siteName: 'Seleneo',
             images: [
                 {

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -64,31 +64,28 @@ export default function AboutPage() {
 
                     <p className="text-base font-light leading-relaxed mb-8">
                         Quick story. Last year—amidst my internship at Notion, <img src="https://upload.wikimedia.org/wikipedia/commons/e/e9/Notion-logo.svg" className="size-6 inline-block px-1 mr-1" />
-                        The idea for Seleneo was born in one of our design channels. My intern project required heavy iterations in Figma,
+                        One of my <Link href="https://www.linkedin.com/posts/notionhq_its-easier-than-ever-to-secure-your-account-activity-7242602102907117568-0jm7"
+                            className="text-primary hover:underline" target="_blank">intern projects</Link> required heavy iterations in Figma,
                         and being a <i>developer-first</i>, I found the tool overwhelming. This soon led to my comment:
                         <br /><br />
                         <img src="/we-need-seleneo.png" className="w-full rounded-md" />
-                        <br />
-                        Naturally, I didn't realize it at the time, but the validation from this comment would soon lead to the creation of the platform you're on right now, Seleneo.{" "}
-                        <span className="text-primary">A design tool built for humans.</span>
                         <br /><br />
                         Once the ColorStack hackathon came around, I didn't think I could do it. So, I joined a team building software for university clubs.
-                        Unforunately for us, when the holidays and life got in the way—our team gave up. I soon knew. <span className="text-primary italic">"This is my moment"</span>{" "},
-                        therefore, I decided to pivot and take on this journey and build out this product. <br /><br />
+                        Unfortunately for us, when the holidays and life got in the way—our team disbanded. I soon knew that I had to pivot, and
+                        therefore, I decided to pivot and take on this journey and build out Seleneo. <br /><br />
 
-                        I wanted a tool that stripped away the complexity while maintaining the power to create beautiful visuals, especially for
-                        me—<i>customer 0</i>—a developer building websites, YouTube thumbnails, and even creating blog content. Ubiquity was the goal.
-                        How can I support all the various workflows our users may have? <br /><br /> <span className="text-primary">And that's how Seleneo was born.</span>
+                        At the core, I wanted a tool that stripped away the complexity while maintaining the power to create beautiful visuals, especially for
+                        me—<i>customer 0</i>—a developer building websites, YouTube thumbnails, and even creating blog content. Ubiquity was the goal, but I wondered:
+                        How can I support all the various workflows our users may have? <br /><br /> <span className="text-primary">And so, Seleneo was born.</span>
                     </p>
 
                     <h2 className="text-2xl font-normal tracking-tighter mt-12 mb-4">
-                        So Why Build Another Design Tool?
+                        So...Why Build Another Design Tool?
                     </h2>
 
                     <p className="text-base font-light leading-relaxed mb-8">
                         As a tried and true builder, I spend a lot of time doing things that aren't writing code.
-                        Building landing pages, crafting marketing materials like YouTube thumbnails, adding open graph images to my projects,
-                        and creating blog content—are all part of the job.
+                        Whether it's designing a website, creating a YouTube thumbnail, or crafting a blog post, I'm constantly creating content.
                         <br /><br />
                         Each piece of content calls for visuals that entice the user to engage and in some cases, effectively communicate ideas.
                         Traditionally, we'd turn to tools like Figma or Sketch, but these professional-grade tools often bring
@@ -99,7 +96,7 @@ export default function AboutPage() {
                         For instance. Want to create a custom open graph image for your website? You're suddenly dealing with an overwhelming interface,
                         subscription plans, and navigating a steep learning curve just to create a simple visual. <br /><br />I wasn't
                         an power user of these tools either, so for this hackathon, I decided to take on the challenge of building a tool that
-                        would make it easy for <span className="text-primary inline-block">anyone</span> to create beautiful visuals.
+                        would make it easy for <span className="text-primary inline-block">anyone</span> to create beautiful visuals quickly and easily.
                     </p>
 
                     <h2 className="text-2xl font-normal tracking-tighter mt-12 mb-4">
@@ -107,22 +104,15 @@ export default function AboutPage() {
                     </h2>
 
                     <p className="text-base font-light leading-relaxed mb-8">
-                        Seleneo strips away the complexity while maintaining the power to create beautiful visuals.
+                        Seleneo strips away the complexity while maintaining the power to craft these elegant visuals.
                         Built with developers and creators in mind, Seleneo is a design tool that's easy to use, fast, and powerful.
                         <br /><br />
 
                         Initially working alone, I got the entire frontend done in about 5 days. However, I soon realized that I needed help with the backend.
                         I decided to bring on the team my friend, 'cracked' backend developer, and software engineer at Oracle, <Link className="text-primary hover:underline" href="https://github.com/Flanderzz" target="_blank">Devine</Link>
-                        —who was more than happy to help. We got the backend done in about 3 days, and the rest was history. <br /><br />
+                        —who was more than happy to help. We got the backend done in about 3 days, and the rest is history. <br /><br />
 
-
-                        With Seleneo, you can create stunning visuals for your website, social media, and more in minutes.
-                        The design studio makes it easy to create custom graphics, thumbnails, and images for your projects, and explore a library of community-generated content.
-                        <br /><br />
-                        With features like adaptive gradient background generation, 100+ image customization options, and cloud-saving,
-                        Seleneo is the perfect tool for <s>developers, designers, and creators</s> <span className="text-primary inline-block">everyone</span> looking to develop meaningful content quickly and easily. <br /><br />
-
-                        Isn't it just funny how, a simple comment in a design channel led to the creation of a tool that would change the way we create visuals?
+                        Isn't it just funny how, a simple comment led to a hackathon project, which led to a full-fledged design tool? <span className="text-primary">Life is funny.</span>
                     </p>
 
                     <h2 className="text-2xl font-normal tracking-tighter mt-12 mb-4">
@@ -133,7 +123,7 @@ export default function AboutPage() {
                         While Seleneo started as a hackathon project, our vision for this project extends far beyond the ColorStack Hackathon. Devine and I truly feel like this project
                         could become something massive, and we're excited to see where it goes from here. <br /><br />
 
-                        Our roadmap includes features like real-time team collaboration and spaces, more sharing options, and an auto-save capbilitiy similar to Google Docs.
+                        Our roadmap includes features like real-time team collaboration and spaces, more sharing options, and an auto-save capability similar to Google Docs.
                         If ColorStack is able to pay for our infrastructure, we'll be able to keep this tool free for everyone. And keep the domain <span className="text-primary">freedesign.fyi</span> alive—literally and figuratively.
                     </p>
 

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -44,6 +44,9 @@ export async function DELETE(request: Request) {
         });
 
         await Promise.all(deleteImagePromises);
+
+        await signOut({ redirect: false });
+
         await prisma.user.delete({ where: { id: userId } });
 
         return Response.json({ message: "Account successfully deleted" }, { status: 200 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -59,12 +59,14 @@ export default function RootLayout({
     return (
         <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`} suppressHydrationWarning suppressContentEditableWarning>
             <head>
-                <Script
-                    defer
-                    src="/stats/script.js"
-                    data-website-id="706fcc6f-f292-4265-bca3-97e91d28432b"
-                    strategy="afterInteractive"
-                />
+                {process.env.VERCEL_ENV === 'production' && (
+                    <Script
+                        defer
+                        src="/stats/script.js"
+                        data-website-id="706fcc6f-f292-4265-bca3-97e91d28432b"
+                        strategy="afterInteractive"
+                    />
+                )}
             </head>
             <body>
                 <Providers>

--- a/components/marketing/call-to-action.tsx
+++ b/components/marketing/call-to-action.tsx
@@ -44,10 +44,10 @@ export function CallToAction() {
                                     </Button>
 
                                     <div className="w-[40rem] h-40 relative mt-4">
-                                        <div className="absolute inset-x-20 top-0 bg-gradient-to-r from-transparent via-indigo-500 to-transparent h-[2px] w-3/4 blur-sm" />
-                                        <div className="absolute inset-x-20 top-0 bg-gradient-to-r from-transparent via-indigo-500 to-transparent h-px w-3/4" />
-                                        <div className="absolute inset-x-60 top-0 bg-gradient-to-r from-transparent via-sky-500 to-transparent h-[5px] w-1/4 blur-sm" />
-                                        <div className="absolute inset-x-60 top-0 bg-gradient-to-r from-transparent via-sky-500 to-transparent h-px w-1/4" />
+                                        <div className="opacity-30 absolute inset-x-20 top-0 bg-gradient-to-r from-transparent via-indigo-500 to-transparent h-[2px] w-3/4 blur-sm" />
+                                        <div className="opacity-30 absolute inset-x-20 top-0 bg-gradient-to-r from-transparent via-indigo-500 to-transparent h-px w-3/4" />
+                                        <div className="opacity-30 absolute inset-x-60 top-0 bg-gradient-to-r from-transparent via-sky-500 to-transparent h-[5px] w-1/4 blur-sm" />
+                                        <div className="opacity-30 absolute inset-x-60 top-0 bg-gradient-to-r from-transparent via-sky-500 to-transparent h-px w-1/4" />
                                         <SparklesCore
                                             background="transparent"
                                             minSize={0.4}

--- a/components/navigation/studio.tsx
+++ b/components/navigation/studio.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, Frame, GalleryVertical, LogOut, LucideIcon, Menu, User } from "lucide-react";
+import { ChevronDown, GalleryVertical, Github, Info, LogOut, LucideIcon, Menu, User } from "lucide-react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -75,7 +75,7 @@ export function StudioNavbar() {
             title: "GitHub",
             href: "https://github.com/dotcomnerd/seleneo",
             description: "Access our open-source repository and contribute to development of Seleneo!",
-            icon: Frame
+            icon: Github
         },
         {
             title: "Community",
@@ -87,7 +87,7 @@ export function StudioNavbar() {
             title: "About",
             href: "/about",
             description: "Learn more about Seleneo, the team behind it, and why we built it.",
-            icon: User
+            icon: Info
         },
     ];
 

--- a/components/studio/main-image.tsx
+++ b/components/studio/main-image.tsx
@@ -14,13 +14,13 @@ import { useFrameOptions } from '@/store/use-frame-options'
 import { useImageOptions, useSelectedLayers } from '@/store/use-image-options'
 import { useMoveable } from '@/store/use-moveable'
 import { useResizeCanvas } from '@/store/use-resize-canvas'
+import ColorThief from 'colorthief'
 import { ImageIcon, Upload } from 'lucide-react'
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react'
 import Dropzone from 'react-dropzone'
 import { Button } from '../ui/button'
 import { BrowserFrame } from './browser-frames'
 import ContextMenuImage from './image-context-menu'
-import ColorThief from 'colorthief'
 
 const ImageUpload = () => {
   const targetRef = useRef<HTMLDivElement>(null)
@@ -74,7 +74,6 @@ const ImageUpload = () => {
     extractColors()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imagesCheck])
-  console.log(images)
 
   useOnClickOutside(targetRef, () => {
     if (isMultipleTargetSelected) return
@@ -315,8 +314,7 @@ function LoadAImage() {
       const file = event.target.files?.[0]
 
       if (file) {
-          const imageUrl = URL.createObjectURL(file)
-          console.log(`imageUrl`, imageUrl)
+        const imageUrl = URL.createObjectURL(file)
         setInitialImageUploaded(true)
 
         setImagesCheck([...imagesCheck, imageUrl])
@@ -362,8 +360,7 @@ function LoadAImage() {
       // const file = event.target.files?.[0]
 
       if (file) {
-          const imageUrl = URL.createObjectURL(file)
-          console.log(`imageUrl`, imageUrl)
+        const imageUrl = URL.createObjectURL(file)
         setInitialImageUploaded(true)
 
         setImagesCheck([...imagesCheck, imageUrl])

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,12 +4,37 @@ import NextAuth from "next-auth"
 import GitHub from "next-auth/providers/github"
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-    providers: [GitHub],
+    providers: [GitHub({
+        profile(profile) {
+            return {
+                id: profile.id.toString(),
+                name: profile.login,
+                email: profile.email,
+                image: profile.avatar_url
+            }
+        }
+    })],
     adapter: PrismaAdapter(prisma),
     callbacks: {
         async session({ session, user }) {
             session.user.id = user.id
             return session
+        },
+        async signIn({ user, profile }) {
+            if (profile && 'login' in profile) {
+                const dbUser = await prisma.user.findUnique({
+                    where: { id: user.id },
+                    select: { name: true }
+                })
+
+                if (dbUser?.name?.includes(' ')) {
+                    await prisma.user.update({
+                        where: { id: user.id },
+                        data: { name: profile.login as string }
+                    })
+                }
+            }
+            return true
         },
     },
 })


### PR DESCRIPTION
- Fixed bug where if your GitHub name has spaces, you can't go to your profile -> now we use the native `login` field for accessing the unique username for each user. I added a handler that updates existing accounts on sign-in too.
- Added a conditional render for the umami analytics script to only be ran in vercel's prod env.
- Improved the UX when you delete your account, and also fixed the race condition of session not being found
- Fixed the `vercel/og` image and metadata generation bug by using the correct prop `username` not `id`
- Removed some nasty console logging exposed to the client
- Updated the copy / writing on the about page
- Updated the Icon for GitHub in the resources navigation menu
- Cleaned the up the CTA styling on the marketing page